### PR TITLE
Fix more optional field regressions

### DIFF
--- a/client.go.tmpl
+++ b/client.go.tmpl
@@ -34,14 +34,14 @@ func New{{.Name | firstLetterToUpper }}Client(addr string, client HTTPClient) {{
 {{- $inputs := $method.Inputs -}}
 {{- $outputs := $method.Outputs }}
 
-func (c *{{$serviceName}}) {{.Name}}(ctx context.Context{{range $_, $input := $inputs}}, {{$input.Name}} {{template "type" dict "Type" $input.Type "TypeMap" $typeMap}}{{end}}) {{if len .Outputs}}({{end}}{{range $i, $output := .Outputs}}{{template "type" dict "Type" $output.Type "TypeMap" $typeMap}}{{if lt $i (len $method.Outputs)}}, {{end}}{{end}}error{{if len .Outputs}}){{end}} {
+func (c *{{$serviceName}}) {{.Name}}(ctx context.Context{{range $_, $input := $inputs}}, {{$input.Name}} {{template "type" dict "Type" $input.Type "Optional" $input.Optional "TypeMap" $typeMap}}{{end}}) {{if len .Outputs}}({{end}}{{range $i, $output := .Outputs}}{{template "type" dict "Type" $output.Type "Optional" $output.Optional "TypeMap" $typeMap}}{{if lt $i (len $method.Outputs)}}, {{end}}{{end}}error{{if len .Outputs}}){{end}} {
 	{{- $inputVar := "nil" -}}
 	{{- $outputVar := "nil" -}}
 	{{- if $inputs | len}}
 	{{- $inputVar = "in"}}
 	in := struct {
 	{{- range $i, $input := $inputs}}
-		Arg{{$i}} {{template "type" dict "Type" $input.Type "TypeMap" $typeMap}} `json:"{{firstLetterToLower $input.Name}}"`
+		Arg{{$i}} {{template "type" dict "Type" $input.Type "Optional" $input.Optional "TypeMap" $typeMap}} `json:"{{firstLetterToLower $input.Name}}"`
 	{{- end}}
 	}{ {{- range $i, $input := $inputs}}{{if gt $i 0}}, {{end}}{{$input.Name}}{{end}}}
 	{{- end}}
@@ -49,7 +49,7 @@ func (c *{{$serviceName}}) {{.Name}}(ctx context.Context{{range $_, $input := $i
 	{{- $outputVar = "&out"}}
 	out := struct {
 	{{- range $i, $output := .Outputs}}
-		Ret{{$i}} {{template "type" dict "Type" $output.Type "TypeMap" $typeMap}} `json:"{{firstLetterToLower $output.Name}}"`
+		Ret{{$i}} {{template "type" dict "Type" $output.Type "Optional" $output.Optional "TypeMap" $typeMap}} `json:"{{firstLetterToLower $output.Name}}"`
 	{{- end}}
 	}{}
 	{{- end}}

--- a/server.go.tmpl
+++ b/server.go.tmpl
@@ -71,7 +71,7 @@ func (s *{{$serviceName}}) serve{{ .Name | firstLetterToUpper }}JSON(ctx context
 	{{- if .Inputs|len}}
 	reqContent := struct {
 	{{- range $i, $input := .Inputs}}
-		Arg{{$i}} {{template "type" dict "Type" $input.Type "TypeMap" $typeMap}} `json:"{{firstLetterToLower $input.Name}}"`
+		Arg{{$i}} {{template "type" dict "Type" $input.Type "Optional" $input.Optional "TypeMap" $typeMap}} `json:"{{firstLetterToLower $input.Name}}"`
 	{{- end}}
 	}{}
 
@@ -93,7 +93,7 @@ func (s *{{$serviceName}}) serve{{ .Name | firstLetterToUpper }}JSON(ctx context
 
 	// Call service method
 	{{- range $i, $output := .Outputs}}
-	var ret{{$i}} {{template "type" dict "Type" $output.Type "TypeMap" $typeMap}}
+	var ret{{$i}} {{template "type" dict "Type" $output.Type "Optional" $output.Optional "TypeMap" $typeMap}}
 	{{- end}}
 	func() {
 		defer func() {
@@ -108,7 +108,7 @@ func (s *{{$serviceName}}) serve{{ .Name | firstLetterToUpper }}JSON(ctx context
 	{{- if .Outputs | len}}
 	respContent := struct {
 	{{- range $i, $output := .Outputs}}
-		Ret{{$i}} {{template "type" dict "Type" $output.Type "TypeMap" $typeMap}} `json:"{{firstLetterToLower $output.Name}}"`
+		Ret{{$i}} {{template "type" dict "Type" $output.Type "Optional" $output.Optional "TypeMap" $typeMap}} `json:"{{firstLetterToLower $output.Name}}"`
 	{{- end}}
 	}{ {{- range $i, $_ := .Outputs}}{{if gt $i 0}}, {{end}}ret{{$i}}{{end}}}
 	{{- end}}

--- a/struct.go.tmpl
+++ b/struct.go.tmpl
@@ -25,7 +25,7 @@ type {{$struct.Name}} struct {
 			{{- $dbTags = printf " db:%q" (get $meta "go.tag.db") -}}
 		{{- end -}}
 	{{- end }}
-	{{$fieldName}} {{if ne $customType ""}}{{$customType}}{{else}}{{if and $field.Optional (not (isStructType $field.Type))}}*{{end}}{{template "type" dict "Type" $field.Type "TypeMap" $typeMap}}{{end}} `{{$jsonTags}}{{$dbTags}}`
+	{{$fieldName}} {{if ne $customType ""}}{{$customType}}{{else}}{{template "type" dict "Type" $field.Type "Optional" $field.Optional "TypeMap" $typeMap}}{{end}} `{{$jsonTags}}{{$dbTags}}`
 {{- end}}
 }
 {{- end }}

--- a/type.go.tmpl
+++ b/type.go.tmpl
@@ -18,7 +18,7 @@
 
 {{- else -}}
 
-    {{if and $optional (not (isStructType $type))}}*{{end}}{{ get $typeMap $type }}
+    {{if $optional}}*{{end}}{{ get $typeMap $type }}
 
 {{- end -}}
 {{- end -}}

--- a/type.go.tmpl
+++ b/type.go.tmpl
@@ -1,6 +1,7 @@
 {{- define "type" -}}
 
 {{- $type := .Type -}}
+{{- $optional := .Optional -}}
 {{- $typeMap := .TypeMap -}}
 
 {{- if isMapType $type -}}
@@ -17,7 +18,7 @@
 
 {{- else -}}
 
-    {{ get $typeMap $type }}
+    {{if and $optional (not (isStructType $type))}}*{{end}}{{ get $typeMap $type }}
 
 {{- end -}}
 {{- end -}}

--- a/types.go.tmpl
+++ b/types.go.tmpl
@@ -22,7 +22,7 @@
 {{range .Services}}
 type {{.Name}} interface {
 	{{- range $_, $method := .Methods}}
-	{{.Name}}(ctx context.Context{{range $_, $input := .Inputs}}, {{$input.Name}} {{template "type" dict "Type" $input.Type "TypeMap" $typeMap}}{{end}}) {{if len .Outputs}}({{end}}{{range $i, $output := .Outputs}}{{template "type" dict "Type" $output.Type "TypeMap" $typeMap}}{{if lt $i (len $method.Outputs)}}, {{end}}{{end}}error{{if len .Outputs}}){{end}}
+	{{.Name}}(ctx context.Context{{range $_, $input := .Inputs}}, {{$input.Name}} {{template "type" dict "Type" $input.Type "Optional" $input.Optional "TypeMap" $typeMap}}{{end}}) {{if len .Outputs}}({{end}}{{range $i, $output := .Outputs}}{{template "type" dict "Type" $output.Type "Optional" $output.Optional "TypeMap" $typeMap}}{{if lt $i (len $method.Outputs)}}, {{end}}{{end}}error{{if len .Outputs}}){{end}}
 	{{- end}}
 }
 {{end}}


### PR DESCRIPTION
Fixed more edge cases against a proprietary RIDL file to make sure the golang target is fully backward compatible with v0.6.0. These edge cases were not really covered by `./_examples` or tests.