### PR TITLE
Implement faster JSON (un)marshaling via jsoniter pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Change any of the following values by passing `-option="Value"` CLI flag to `web
 | `-pkg=<name>`            | package name                              | `"proto"`                  |          |
 | `-client`                | generate client code                      | unset (`false`)            |          |
 | `-server`                | generate server code                      | unset (`false`)            |          |
+| `-json=jsoniter`         | use alternative json encoding package     | unset (`"stdlib"`)         | v0.12.0  |
 | `-importTypesFrom=<pkg>` | do not generate types; import from a pkg  | unset (`""`)               | v0.12.0  |
 | `-legacyErrors=true`     | enable legacy errors (v0.10.0 or older)   | unset (`false`)            | v0.11.0  |
 

--- a/imports.go.tmpl
+++ b/imports.go.tmpl
@@ -6,10 +6,13 @@
 {{- $stdlibImports := dict -}}
 {{- set $stdlibImports "context" "" -}}
 {{- set $stdlibImports "errors" "" -}}
-{{- set $stdlibImports "encoding/json" "" -}}
 {{- set $stdlibImports "fmt" "" -}}
 {{- set $stdlibImports "io/ioutil" "" -}}
 {{- set $stdlibImports "net/http" "" -}}
+
+{{- if eq $opts.json "stdlib" -}}
+	{{- set $stdlibImports "encoding/json" "" -}}
+{{- end -}}
 
 {{- if $opts.client}}
 	{{- set $stdlibImports "bytes" "" -}}
@@ -33,17 +36,29 @@
 	{{- end -}}
 {{- end -}}
 
+import (
+
 {{- /* Print stdlib imports. */ -}}
 {{- range $import, $rename := $stdlibImports }}
 	{{if ne $rename ""}}{{$rename}} {{end}}"{{$import}}"
+{{- end -}}
+
+{{- /* Print custom type imports. */ -}}
+{{ $imports := dict }}
+
+{{- if eq $opts.json "stdlib" -}}
+	{{- /* Already imported in the stdlib section. */ -}}
+{{- else if eq $opts.json "jsoniter" -}}
+	{{- set $imports "github.com/json-iterator/go" "jsoniter" -}}
+{{- else -}}
+	{{- stderrPrintf "unsupported -json=%s" $opts.json -}}
+	{{- exit 1 -}}
 {{- end -}}
 
 {{ if ne $opts.importTypesFrom "" }}
 
 	"{{ $opts.importTypesFrom }}"
 {{- else }}
-	{{- /* Print custom type imports. */ -}}
-	{{ $imports := dict }}
 	{{ range $_, $type := $types -}}
 		{{- range $_, $field := $type.Fields -}}
 			{{- range $meta := $field.Meta -}}
@@ -56,6 +71,12 @@
 	{{- range $import, $rename := $imports }}
 	{{if ne $rename ""}}{{$rename}} {{end}}"{{$import}}"
 	{{- end -}}
-{{- end }}
+{{ end }}
+)
+
+{{- if eq $opts.json "jsoniter" }}
+
+var json = jsoniter.ConfigCompatibleWithStandardLibrary
+{{ end -}}
 
 {{- end -}}

--- a/main.go.tmpl
+++ b/main.go.tmpl
@@ -5,6 +5,7 @@
 {{- set $opts "pkg" (default .Opts.pkg "proto") -}}
 {{- set $opts "client" (ternary (in .Opts.client "" "true") true false) -}}
 {{- set $opts "server" (ternary (in .Opts.server "" "true") true false) -}}
+{{- set $opts "json" (default .Opts.json "stdlib") -}}
 {{- set $opts "importTypesFrom" (default .Opts.importTypesFrom "" ) -}}
 {{- set $opts "legacyErrors" (ternary (in .Opts.legacyErrors "true") true false) -}}
 
@@ -66,9 +67,7 @@
 // {{.WebrpcGenCommand}}
 package {{get $opts "pkg"}}
 
-import (
-  {{- template "imports" dict "Types" .Types "Opts" $opts }}
-)
+{{template "imports" dict "Types" .Types "Opts" $opts }}
 
 // WebRPC description and code-gen version
 func WebRPCVersion() string {


### PR DESCRIPTION
```
webrpc-gen -schema=proto.ridl -target=golang -client -json=jsoniter -out=client.gen.go
```

Fixes https://github.com/webrpc/webrpc/issues/20

Good read: https://www.cockroachlabs.com/blog/high-performance-json-parsing/