### PR TITLE
Implement getters for webrpc-specific context values

### DIFF
--- a/_examples/golang-basics/example.gen.go
+++ b/_examples/golang-basics/example.gen.go
@@ -628,6 +628,25 @@ var (
 	MethodNameCtxKey = &contextKey{"MethodName"}
 )
 
+func ServiceNameFromContext(ctx context.Context) string {
+	service, _ := ctx.Value(ServiceNameCtxKey).(string)
+	return service
+}
+
+func MethodNameFromContext(ctx context.Context) string {
+	method, _ := ctx.Value(MethodNameCtxKey).(string)
+	return method
+}
+
+func RequestFromContext(ctx context.Context) *http.Request {
+	r, _ := ctx.Value(HTTPRequestCtxKey).(*http.Request)
+	return r
+}
+func ResponseWriterFromContext(ctx context.Context) http.ResponseWriter {
+	w, _ := ctx.Value(HTTPResponseWriterCtxKey).(http.ResponseWriter)
+	return w
+}
+
 // Copied from https://github.com/golang-cz/nilslice
 func initializeNilSlices(obj interface{}) interface{} {
 	v := reflect.ValueOf(obj)

--- a/_examples/golang-imports/api.gen.go
+++ b/_examples/golang-imports/api.gen.go
@@ -434,6 +434,25 @@ var (
 	MethodNameCtxKey = &contextKey{"MethodName"}
 )
 
+func ServiceNameFromContext(ctx context.Context) string {
+	service, _ := ctx.Value(ServiceNameCtxKey).(string)
+	return service
+}
+
+func MethodNameFromContext(ctx context.Context) string {
+	method, _ := ctx.Value(MethodNameCtxKey).(string)
+	return method
+}
+
+func RequestFromContext(ctx context.Context) *http.Request {
+	r, _ := ctx.Value(HTTPRequestCtxKey).(*http.Request)
+	return r
+}
+func ResponseWriterFromContext(ctx context.Context) http.ResponseWriter {
+	w, _ := ctx.Value(HTTPResponseWriterCtxKey).(http.ResponseWriter)
+	return w
+}
+
 
 //
 // Errors

--- a/helpers.go.tmpl
+++ b/helpers.go.tmpl
@@ -20,14 +20,35 @@ var (
 
 {{- if $opts.server}}
 	HTTPResponseWriterCtxKey = &contextKey{"HTTPResponseWriter"}
-{{- end}}
-
+{{ end}}
 	HTTPRequestCtxKey = &contextKey{"HTTPRequest"}
 
 	ServiceNameCtxKey = &contextKey{"ServiceName"}
 
 	MethodNameCtxKey = &contextKey{"MethodName"}
 )
+
+func ServiceNameFromContext(ctx context.Context) string {
+	service, _ := ctx.Value(ServiceNameCtxKey).(string)
+	return service
+}
+
+func MethodNameFromContext(ctx context.Context) string {
+	method, _ := ctx.Value(MethodNameCtxKey).(string)
+	return method
+}
+
+func RequestFromContext(ctx context.Context) *http.Request {
+	r, _ := ctx.Value(HTTPRequestCtxKey).(*http.Request)
+	return r
+}
+
+{{- if $opts.server}}
+func ResponseWriterFromContext(ctx context.Context) http.ResponseWriter {
+	w, _ := ctx.Value(HTTPResponseWriterCtxKey).(http.ResponseWriter)
+	return w
+}
+{{- end}}
 
 {{- if and $opts.fixEmptyArrays $opts.server}}
 


### PR DESCRIPTION
Makes the webrpc-specific context values (e.g. `http.ResponseWriter` and `*http.Request`) easy  to discover.

```go
r := proto.RequestFromContext(ctx)
w := proto.ResponseWriterFromContext(ctx)
service := proto.ServiceNameFromContext(ctx)
method := proto.MethodNameFromContext(ctx)
```