### PR TITLE
Experimental: Implement server hooks via -hooks=true option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ webrpc-gen -schema=example.ridl -target=./local-go-templates-on-disk -out=./exam
 
 As you can see, the `-target` supports default `golang`, any git URI, or a local folder :)
 
-### Set custom template variables
-Change any of the following values by passing `-option="Value"` CLI flag to `webrpc-gen`.
+## Template options
+Change any of the following options by passing `-option="Value"` CLI flag to `webrpc-gen`.
 
 | webrpc-gen -option | Default    | Description                                                                 | Added in |
 |--------------------|------------|-----------------------------------------------------------------------------|----------|
@@ -37,6 +37,13 @@ Example:
 ```
 webrpc-gen -schema=./proto.json -target=golang -out server.gen.go -pkg=main -server
 ```
+
+## Experimental options
+**Note: These options are experimental and might be subject to change.**
+
+| webrpc-gen -option | Default    | Description                                                   | Added in               |
+|--------------------|------------|---------------------------------------------------------------|------------------------|
+| `-hooks`           | `false`    | enable server-side hooks `BeforeMethod()` and `AfterMethod()` | v0.13.2 (experimental) |
 
 ## Set custom Go field meta tags in your RIDL file
 

--- a/_examples/golang-basics/example.gen.go
+++ b/_examples/golang-basics/example.gen.go
@@ -141,7 +141,7 @@ type exampleServiceServer struct {
 	ExampleService
 }
 
-func NewExampleServiceServer(svc ExampleService) WebRPCServer {
+func NewExampleServiceServer(svc ExampleService) *exampleServiceServer {
 	return &exampleServiceServer{
 		ExampleService: svc,
 	}
@@ -233,7 +233,8 @@ func (s *exampleServiceServer) serveStatusJSON(ctx context.Context, w http.Respo
 	}{ret0}
 	respBody, err := json.Marshal(initializeNilSlices(respPayload))
 	if err != nil {
-		RespondWithError(w, ErrorWithCause(ErrWebrpcBadResponse, fmt.Errorf("failed to marshal json response: %w", err)))
+		rpcErr := ErrorWithCause(ErrWebrpcBadResponse, fmt.Errorf("failed to marshal json response: %w", err))
+		RespondWithError(w, rpcErr)
 		return
 	}
 
@@ -257,7 +258,8 @@ func (s *exampleServiceServer) serveVersionJSON(ctx context.Context, w http.Resp
 	}{ret0}
 	respBody, err := json.Marshal(initializeNilSlices(respPayload))
 	if err != nil {
-		RespondWithError(w, ErrorWithCause(ErrWebrpcBadResponse, fmt.Errorf("failed to marshal json response: %w", err)))
+		rpcErr := ErrorWithCause(ErrWebrpcBadResponse, fmt.Errorf("failed to marshal json response: %w", err))
+		RespondWithError(w, rpcErr)
 		return
 	}
 
@@ -271,7 +273,8 @@ func (s *exampleServiceServer) serveGetUserJSON(ctx context.Context, w http.Resp
 
 	reqBody, err := io.ReadAll(r.Body)
 	if err != nil {
-		RespondWithError(w, ErrorWithCause(ErrWebrpcBadRequest, fmt.Errorf("failed to read request data: %w", err)))
+		rpcErr := ErrorWithCause(ErrWebrpcBadRequest, fmt.Errorf("failed to read request data: %w", err))
+		RespondWithError(w, rpcErr)
 		return
 	}
 	defer r.Body.Close()
@@ -281,7 +284,8 @@ func (s *exampleServiceServer) serveGetUserJSON(ctx context.Context, w http.Resp
 		Arg1 uint64            `json:"userID"`
 	}{}
 	if err := json.Unmarshal(reqBody, &reqPayload); err != nil {
-		RespondWithError(w, ErrorWithCause(ErrWebrpcBadRequest, fmt.Errorf("failed to unmarshal request data: %w", err)))
+		rpcErr := ErrorWithCause(ErrWebrpcBadRequest, fmt.Errorf("failed to unmarshal request data: %w", err))
+		RespondWithError(w, rpcErr)
 		return
 	}
 
@@ -297,7 +301,8 @@ func (s *exampleServiceServer) serveGetUserJSON(ctx context.Context, w http.Resp
 	}{ret0}
 	respBody, err := json.Marshal(initializeNilSlices(respPayload))
 	if err != nil {
-		RespondWithError(w, ErrorWithCause(ErrWebrpcBadResponse, fmt.Errorf("failed to marshal json response: %w", err)))
+		rpcErr := ErrorWithCause(ErrWebrpcBadResponse, fmt.Errorf("failed to marshal json response: %w", err))
+		RespondWithError(w, rpcErr)
 		return
 	}
 
@@ -311,7 +316,8 @@ func (s *exampleServiceServer) serveFindUserJSON(ctx context.Context, w http.Res
 
 	reqBody, err := io.ReadAll(r.Body)
 	if err != nil {
-		RespondWithError(w, ErrorWithCause(ErrWebrpcBadRequest, fmt.Errorf("failed to read request data: %w", err)))
+		rpcErr := ErrorWithCause(ErrWebrpcBadRequest, fmt.Errorf("failed to read request data: %w", err))
+		RespondWithError(w, rpcErr)
 		return
 	}
 	defer r.Body.Close()
@@ -320,7 +326,8 @@ func (s *exampleServiceServer) serveFindUserJSON(ctx context.Context, w http.Res
 		Arg0 *SearchFilter `json:"s"`
 	}{}
 	if err := json.Unmarshal(reqBody, &reqPayload); err != nil {
-		RespondWithError(w, ErrorWithCause(ErrWebrpcBadRequest, fmt.Errorf("failed to unmarshal request data: %w", err)))
+		rpcErr := ErrorWithCause(ErrWebrpcBadRequest, fmt.Errorf("failed to unmarshal request data: %w", err))
+		RespondWithError(w, rpcErr)
 		return
 	}
 
@@ -337,7 +344,8 @@ func (s *exampleServiceServer) serveFindUserJSON(ctx context.Context, w http.Res
 	}{ret0, ret1}
 	respBody, err := json.Marshal(initializeNilSlices(respPayload))
 	if err != nil {
-		RespondWithError(w, ErrorWithCause(ErrWebrpcBadResponse, fmt.Errorf("failed to marshal json response: %w", err)))
+		rpcErr := ErrorWithCause(ErrWebrpcBadResponse, fmt.Errorf("failed to marshal json response: %w", err))
+		RespondWithError(w, rpcErr)
 		return
 	}
 
@@ -351,7 +359,8 @@ func (s *exampleServiceServer) serveLogEventJSON(ctx context.Context, w http.Res
 
 	reqBody, err := io.ReadAll(r.Body)
 	if err != nil {
-		RespondWithError(w, ErrorWithCause(ErrWebrpcBadRequest, fmt.Errorf("failed to read request data: %w", err)))
+		rpcErr := ErrorWithCause(ErrWebrpcBadRequest, fmt.Errorf("failed to read request data: %w", err))
+		RespondWithError(w, rpcErr)
 		return
 	}
 	defer r.Body.Close()
@@ -360,7 +369,8 @@ func (s *exampleServiceServer) serveLogEventJSON(ctx context.Context, w http.Res
 		Arg0 string `json:"event"`
 	}{}
 	if err := json.Unmarshal(reqBody, &reqPayload); err != nil {
-		RespondWithError(w, ErrorWithCause(ErrWebrpcBadRequest, fmt.Errorf("failed to unmarshal request data: %w", err)))
+		rpcErr := ErrorWithCause(ErrWebrpcBadRequest, fmt.Errorf("failed to unmarshal request data: %w", err))
+		RespondWithError(w, rpcErr)
 		return
 	}
 
@@ -377,15 +387,15 @@ func (s *exampleServiceServer) serveLogEventJSON(ctx context.Context, w http.Res
 }
 
 func RespondWithError(w http.ResponseWriter, err error) {
-	rpcErr, ok := err.(WebRPCError)
-	if !ok {
+	var rpcErr WebRPCError
+	if !errors.As(err, &rpcErr) {
 		rpcErr = ErrorWithCause(ErrWebrpcEndpoint, err)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(rpcErr.HTTPStatus)
 
-	respBody, _ := json.Marshal(rpcErr)
+	respBody, _ := json.Marshal(err)
 	w.Write(respBody)
 }
 

--- a/main.go.tmpl
+++ b/main.go.tmpl
@@ -9,7 +9,7 @@
 {{- set $opts "json" (default .Opts.json "stdlib") -}}
 {{- set $opts "importTypesFrom" (default .Opts.importTypesFrom "" ) -}}
 {{- set $opts "fixEmptyArrays" (ternary (in .Opts.fixEmptyArrays "" "true") true false) -}}
-{{- set $opts "errorStackTrace" (ternary (in .Opts.errorStackTrace "" "true") true false) -}}
+{{- set $opts "hooks" (ternary (in .Opts.hooks "" "true") true false) -}}
 {{- set $opts "legacyErrors" (ternary (in .Opts.legacyErrors "" "true") true false) -}}
 
 {{- $typePrefix := (last (split "/" $opts.importTypesFrom)) -}}

--- a/server.go.tmpl
+++ b/server.go.tmpl
@@ -8,23 +8,66 @@
 // Server
 //
 
-type WebRPCServer interface {
-	http.Handler
+{{if $opts.hooks -}}
+type Config struct {
+	BeforeMethod       func(ctx context.Context) error
+	AfterMethodSuccess func(ctx context.Context)
+	AfterMethodError   func(ctx context.Context, err WebRPCError) error
 }
+
+var defaultConfig = Config{
+	BeforeMethod:       func(ctx context.Context) error { return nil },
+	AfterMethodSuccess: func(ctx context.Context) {},
+	AfterMethodError:   func(ctx context.Context, err WebRPCError) error { return err },
+}
+
+{{end}}
 
 {{- range .Services}}
 {{- $name := .Name -}}
 {{ $serviceName := (printf "%sServer" (.Name | firstLetterToLower)) }}
 
+{{- if $opts.hooks -}}
+type {{$serviceName}} struct {
+	*Config
+	{{$typePrefix}}{{.Name}}
+	http.Handler
+}
+
+func New{{ .Name | firstLetterToUpper }}Server(svc {{$typePrefix}}{{.Name}}, cfg *Config) *{{$serviceName}} {
+	config := defaultConfig
+	if cfg != nil {
+		if cfg.BeforeMethod != nil {
+			config.BeforeMethod = cfg.BeforeMethod
+		}
+		if cfg.AfterMethodSuccess != nil {
+			config.AfterMethodSuccess = cfg.AfterMethodSuccess
+		}
+		if cfg.AfterMethodError != nil {
+			config.AfterMethodError = cfg.AfterMethodError
+		}
+	}
+
+	return &{{$serviceName}}{
+		{{.Name}}: svc,
+		Config: &config,
+	}
+}
+{{- else -}}
+type WebRPCServer interface {
+	http.Handler
+}
+
 type {{$serviceName}} struct {
 	{{$typePrefix}}{{.Name}}
 }
 
-func New{{ .Name | firstLetterToUpper }}Server(svc {{$typePrefix}}{{.Name}}) WebRPCServer {
+func New{{ .Name | firstLetterToUpper }}Server(svc {{$typePrefix}}{{.Name}}) *{{$serviceName}} {
 	return &{{$serviceName}}{
 		{{.Name}}: svc,
 	}
 }
+{{- end}}
 
 func (s *{{$serviceName}}) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer func() {
@@ -76,10 +119,18 @@ func (s *{{$serviceName}}) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (s *{{$serviceName}}) serve{{ .Name | firstLetterToUpper }}JSON(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	ctx = context.WithValue(ctx, MethodNameCtxKey, "{{.Name}}")
 
+	{{if $opts.hooks -}}
+	if err := s.BeforeMethod(ctx); err != nil {
+		RespondWithError(w, err)
+		return
+	}
+	{{- end}}
+
 	{{ if gt (len .Inputs) 0 -}}
 	reqBody, err := io.ReadAll(r.Body)
 	if err != nil {
-		RespondWithError(w, ErrorWithCause(ErrWebrpcBadRequest, fmt.Errorf("failed to read request data: %w", err)))
+		rpcErr := ErrorWithCause(ErrWebrpcBadRequest, fmt.Errorf("failed to read request data: %w", err))
+		RespondWithError(w, {{if $opts.hooks }}s.AfterMethodError(ctx, rpcErr){{else}}rpcErr{{end}})
 		return
 	}
 	defer r.Body.Close()
@@ -90,7 +141,8 @@ func (s *{{$serviceName}}) serve{{ .Name | firstLetterToUpper }}JSON(ctx context
 	{{- end}}
 	}{}
 	if err := json.Unmarshal(reqBody, &reqPayload); err != nil {
-		RespondWithError(w, ErrorWithCause(ErrWebrpcBadRequest, fmt.Errorf("failed to unmarshal request data: %w", err)))
+		rpcErr := ErrorWithCause(ErrWebrpcBadRequest, fmt.Errorf("failed to unmarshal request data: %w", err))
+		RespondWithError(w, {{if $opts.hooks }}s.AfterMethodError(ctx, rpcErr){{else}}rpcErr{{end}})
 		return
 	}
 
@@ -99,7 +151,15 @@ func (s *{{$serviceName}}) serve{{ .Name | firstLetterToUpper }}JSON(ctx context
 	// Call service method implementation.
 	{{range $i, $output := .Outputs}}ret{{$i}}, {{end}}err {{if or (eq (len .Inputs) 0) (gt (len .Outputs) 0)}}:{{end}}= s.{{$name}}.{{.Name}}(ctx{{range $i, $_ := .Inputs}}, reqPayload.Arg{{$i}}{{end}})
 	if err != nil {
+		{{if $opts.hooks -}}
+		rpcErr, ok := err.(WebRPCError)
+		if !ok {
+			rpcErr = ErrorWithCause(ErrWebrpcEndpoint, err)
+		}
+		RespondWithError(w, s.AfterMethodError(ctx, rpcErr))
+		{{else -}}
 		RespondWithError(w, err)
+		{{- end}}
 		return
 	}
 
@@ -119,7 +179,8 @@ func (s *{{$serviceName}}) serve{{ .Name | firstLetterToUpper }}JSON(ctx context
 	respBody, err := json.Marshal(respPayload)
 	{{ end -}}
 	if err != nil {
-		RespondWithError(w, ErrorWithCause(ErrWebrpcBadResponse, fmt.Errorf("failed to marshal json response: %w", err)))
+		rpcErr := ErrorWithCause(ErrWebrpcBadResponse, fmt.Errorf("failed to marshal json response: %w", err))
+		RespondWithError(w, {{if $opts.hooks }}s.AfterMethodError(ctx, rpcErr){{else}}rpcErr{{end}})
 		return
 	}
 	{{- end}}
@@ -131,21 +192,25 @@ func (s *{{$serviceName}}) serve{{ .Name | firstLetterToUpper }}JSON(ctx context
 	w.Write(respBody)
 	{{- else }}
 	w.Write([]byte("{}"))
+	{{- end }}
+
+	{{- if $opts.hooks }}
+	s.AfterMethodSuccess(ctx)
 	{{- end}}
 }
 {{end}}
 {{end -}}
 
 func RespondWithError(w http.ResponseWriter, err error) {
-	rpcErr, ok := err.(WebRPCError)
-	if !ok {
+	var rpcErr WebRPCError
+	if !errors.As(err, &rpcErr) {
 		rpcErr = ErrorWithCause(ErrWebrpcEndpoint, err)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(rpcErr.HTTPStatus)
 
-	respBody, _ := json.Marshal(rpcErr)
+	respBody, _ := json.Marshal(err)
 	w.Write(respBody)
 }
 


### PR DESCRIPTION
Experimental feature. Subject to change.

## Example
`webrpc-gen -schema=proto.ridl -target=golang -server` **`-hooks=true`**

```go
// Example:
rpcHandler := proto.NewVideoServer(rpc.Server, &proto.Config{
	// BeforeMethod() hook is called before each RPC method is invoked.
	// If BeforeMethod() returns non-nil error, webrpc responds with proper
	// WebRPC error and halts the method execution.
	BeforeMethod: authorizeUser,

	// AfterMethodError() hook is called after each RPC method returns error.
	// It's useful e.g. for logging webrpc errors.
	AfterMethodError: logWebrpcErrors,

	// AfterMethodSuccess() hook is called after each RPC method returns nil error.
})
```

```go
func authorizeUser(ctx context.Context) error {
	user := auth.UserFromContext(ctx)
	method := proto.MethodNameFromCtx(ctx)
	
	_, ok := acl.Authorize(user, method)
	if !ok {
		return proto.ErrUnauthorized
	}

	return nil
}

func logWebrpcErrors(ctx context.Context, err WebRPCError) {
	// Add webrpc error to the request log line
	httplog.LogEntrySetField(ctx, "webrpcError", err)
}
```

Note: We might as well introduce client-side hooks, e.g. for debugging requests/responses more easily than with a custom `http.Transport`.