### PR TITLE
Implement -errorStackTrace opt-in option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Change any of the following values by passing `-option="Value"` CLI flag to `web
 | `-types=false`     | `true`     | don't generate types                                                        | v0.13.0  |
 | `-json=jsoniter`   | `"stdlib"` | use alternative json encoding package                                       | v0.12.0  |
 | `-fixEmptyArrays`  | `false`    | force empty array `[]` instead of `null` in JSON (see Go [#27589][go27589]) | v0.13.0  |
+| `-errorStackTrace` | `false`    | enables error stack traces                                                  | v0.14.0  |
 | `-legacyErrors`    | `false`    | enable legacy errors (v0.10.0 or older)                                     | v0.11.0  |
 
 Example:

--- a/errors.go.tmpl
+++ b/errors.go.tmpl
@@ -13,6 +13,11 @@ type WebRPCError struct {
 	Cause      string `json:"cause,omitempty"`
 	HTTPStatus int    `json:"status"`
 	cause      error
+
+	{{- if $opts.errorStackTrace }}
+	{{- /* The below field is reflect-compatible with golang.org/x/xerrors.*/}}
+	frame      struct { frames [3]uintptr }
+	{{- end}}
 }
 
 var _ error = WebRPCError{}
@@ -44,8 +49,17 @@ func ErrorWithCause(rpcErr WebRPCError, cause error) WebRPCError {
 	err := rpcErr
 	err.cause = cause
 	err.Cause = cause.Error()
+	{{- if $opts.errorStackTrace }}
+	runtime.Callers(1, err.frame.frames[:])
+	{{- end}}
 	return err
 }
+
+{{ if $opts.errorStackTrace -}}
+func (e WebRPCError) StackFrames() []uintptr {
+	return e.frame.frames[:]
+}
+{{- end }}
 
 // Webrpc errors
 var (

--- a/imports.go.tmpl
+++ b/imports.go.tmpl
@@ -13,6 +13,10 @@
 	{{- set $stdlibImports "encoding/json" "" -}}
 {{- end -}}
 
+{{- if $opts.errorStackTrace }}
+	{{- set $stdlibImports "runtime" "" -}}
+{{- end -}}
+
 {{- if $opts.client }}
 	{{- set $stdlibImports "bytes" "" -}}
 	{{- set $stdlibImports "io" "" -}}

--- a/main.go.tmpl
+++ b/main.go.tmpl
@@ -9,6 +9,7 @@
 {{- set $opts "json" (default .Opts.json "stdlib") -}}
 {{- set $opts "importTypesFrom" (default .Opts.importTypesFrom "" ) -}}
 {{- set $opts "fixEmptyArrays" (ternary (in .Opts.fixEmptyArrays "" "true") true false) -}}
+{{- set $opts "errorStackTrace" (ternary (in .Opts.errorStackTrace "" "true") true false) -}}
 {{- set $opts "legacyErrors" (ternary (in .Opts.legacyErrors "" "true") true false) -}}
 
 {{- $typePrefix := (last (split "/" $opts.importTypesFrom)) -}}


### PR DESCRIPTION
The stack trace is reflect-compatible with:
- github.com/pkg/errors
- golang.org/x/xerrors
- golang.org/x/exp/errors

and thus can be inspected via reflect pkg by tools like:
- https://github.com/getsentry/sentry-go
- https://github.com/golang-cz/devslog
- etc.