### PR TITLE
Implement err.WithCause(), a shorter version of proto.ErrorWithCause()

### DIFF
--- a/_examples/golang-basics/example.gen.go
+++ b/_examples/golang-basics/example.gen.go
@@ -715,6 +715,13 @@ func (e WebRPCError) Unwrap() error {
 	return e.cause
 }
 
+func (e WebRPCError) WithCause(cause error) error {
+	err := e
+	err.cause = cause
+	err.Cause = cause.Error()
+	return err
+}
+
 func ErrorWithCause(rpcErr WebRPCError, cause error) WebRPCError {
 	err := rpcErr
 	err.cause = cause

--- a/_examples/golang-basics/example.gen.go
+++ b/_examples/golang-basics/example.gen.go
@@ -722,11 +722,9 @@ func (e WebRPCError) WithCause(cause error) error {
 	return err
 }
 
+// Deprecated: Use .WithCause() method on WebRPCError.
 func ErrorWithCause(rpcErr WebRPCError, cause error) WebRPCError {
-	err := rpcErr
-	err.cause = cause
-	err.Cause = cause.Error()
-	return err
+	return rpcErr.WithCause(cause)
 }
 
 // Webrpc errors

--- a/_examples/golang-imports/api.gen.go
+++ b/_examples/golang-imports/api.gen.go
@@ -489,11 +489,9 @@ func (e WebRPCError) WithCause(cause error) error {
 	return err
 }
 
+// Deprecated: Use .WithCause() method on WebRPCError.
 func ErrorWithCause(rpcErr WebRPCError, cause error) WebRPCError {
-	err := rpcErr
-	err.cause = cause
-	err.Cause = cause.Error()
-	return err
+	return rpcErr.WithCause(cause)
 }
 
 // Webrpc errors

--- a/_examples/golang-imports/api.gen.go
+++ b/_examples/golang-imports/api.gen.go
@@ -482,6 +482,13 @@ func (e WebRPCError) Unwrap() error {
 	return e.cause
 }
 
+func (e WebRPCError) WithCause(cause error) error {
+	err := e
+	err.cause = cause
+	err.Cause = cause.Error()
+	return err
+}
+
 func ErrorWithCause(rpcErr WebRPCError, cause error) WebRPCError {
 	err := rpcErr
 	err.cause = cause

--- a/errors.go.tmpl
+++ b/errors.go.tmpl
@@ -45,6 +45,16 @@ func (e WebRPCError) Unwrap() error {
 	return e.cause
 }
 
+func (e WebRPCError) WithCause(cause error) error {
+	err := e
+	err.cause = cause
+	err.Cause = cause.Error()
+	{{- if $opts.errorStackTrace }}
+	runtime.Callers(1, err.frame.frames[:])
+	{{- end}}
+	return err
+}
+
 func ErrorWithCause(rpcErr WebRPCError, cause error) WebRPCError {
 	err := rpcErr
 	err.cause = cause

--- a/errors.go.tmpl
+++ b/errors.go.tmpl
@@ -55,14 +55,9 @@ func (e WebRPCError) WithCause(cause error) error {
 	return err
 }
 
+// Deprecated: Use .WithCause() method on WebRPCError.
 func ErrorWithCause(rpcErr WebRPCError, cause error) WebRPCError {
-	err := rpcErr
-	err.cause = cause
-	err.Cause = cause.Error()
-	{{- if $opts.errorStackTrace }}
-	runtime.Callers(1, err.frame.frames[:])
-	{{- end}}
-	return err
+	return rpcErr.WithCause(cause)
 }
 
 {{- if $opts.errorStackTrace -}}


### PR DESCRIPTION
This is an experimental support for a shorter version of `proto.ErrorWithCause(proto.ErrXXX, err)`

```diff
 org, err := s.DB.Org.FindByExternalApplicationId(applicationId)
 if err != nil {
-	return "", proto.ErrorWithCause(proto.ErrOrgNotFound, err)
+	return "", proto.ErrOrgNotFound.WithCause(err)
 }
```
