### PR TITLE
Add an extra condition in WebRPCError.Is to check against target nil …

### DIFF
--- a/errors.go.tmpl
+++ b/errors.go.tmpl
@@ -31,7 +31,7 @@ func (e WebRPCError) Error() string {
 
 func (e WebRPCError) Is(target error) bool {
 	if target == nil {
-		rerturn false
+		return false
 	}
 	if rpcErr, ok := target.(WebRPCError); ok {
 		return rpcErr.Code == e.Code

--- a/errors.go.tmpl
+++ b/errors.go.tmpl
@@ -30,6 +30,9 @@ func (e WebRPCError) Error() string {
 }
 
 func (e WebRPCError) Is(target error) bool {
+	if target == nil {
+		rerturn false
+	}
 	if rpcErr, ok := target.(WebRPCError); ok {
 		return rpcErr.Code == e.Code
 	}


### PR DESCRIPTION
Hey guys,

I've recently working on my [own compiler](https://compiler.ella.to), which was inspired by this project and I was looking at the Error generation of WebRPC. One thing I found and I want to see if my assumption is correct. 

Based on the following code, WebRPC implements a new method call `Is` for WebRPCError type and the implementation of is as follows:

```golang
func (e WebRPCError) Is(target error) bool {
	if rpcErr, ok := target.(WebRPCError); ok {
		return rpcErr.Code == e.Code
	}
	return errors.Is(e.cause, target)
}
```

However, there is a scenario that causes this method to return true when both `target` argument and `e.cause` are nil values. So I'm assuming having an extra check at the beginning of the function will solve that.

Let me your thoughts