### PR TITLE
fix: multiple services not supported due to go fmt error

### DIFF
--- a/types.go.tmpl
+++ b/types.go.tmpl
@@ -57,8 +57,8 @@ type {{$service.Name}} interface {
 }
 {{- end }}
 
-{{- range $_, $method := $service.Methods -}}
-{{ if eq $method.StreamOutput true }}
+{{- range $_, $method := $service.Methods }}
+{{ if eq $method.StreamOutput true -}}
 type {{$method.Name}}StreamWriter interface {
 	Write({{range $i, $output := $method.Outputs}}{{if gt $i 0}}, {{end}}{{$output.Name}} {{template "field" dict "Name" $output.Name "Type" $output.Type "Optional" $output.Optional "TypeMap" $typeMap "TypePrefix" $typePrefix "TypeMeta" $output.Meta}}{{end}}) error
 }


### PR DESCRIPTION
Generating from .ridl files with multiple services now works again with this fix (see #61). 