### PR TITLE
Fix .Causef() syntax error (shadowed fmt pkg name)

### DIFF
--- a/_examples/golang-basics/example.gen.go
+++ b/_examples/golang-basics/example.gen.go
@@ -864,8 +864,8 @@ func (e WebRPCError) WithCause(cause error) WebRPCError {
 	return err
 }
 
-func (e WebRPCError) WithCausef(fmt string, args ...interface{}) WebRPCError {
-	cause := fmt.Errorf(fmt, args...)
+func (e WebRPCError) WithCausef(format string, args ...interface{}) WebRPCError {
+	cause := fmt.Errorf(format, args...)
 	err := e
 	err.cause = cause
 	err.Cause = cause.Error()

--- a/_examples/golang-imports/api.gen.go
+++ b/_examples/golang-imports/api.gen.go
@@ -574,8 +574,8 @@ func (e WebRPCError) WithCause(cause error) WebRPCError {
 	return err
 }
 
-func (e WebRPCError) WithCausef(fmt string, args ...interface{}) WebRPCError {
-	cause := fmt.Errorf(fmt, args...)
+func (e WebRPCError) WithCausef(format string, args ...interface{}) WebRPCError {
+	cause := fmt.Errorf(format, args...)
 	err := e
 	err.cause = cause
 	err.Cause = cause.Error()

--- a/errors.go.tmpl
+++ b/errors.go.tmpl
@@ -58,8 +58,8 @@ func (e WebRPCError) WithCause(cause error) WebRPCError {
 	return err
 }
 
-func (e WebRPCError) WithCausef(fmt string, args ...interface{}) WebRPCError {
-	cause := fmt.Errorf(fmt, args...)
+func (e WebRPCError) WithCausef(format string, args ...interface{}) WebRPCError {
+	cause := fmt.Errorf(format, args...)
 	err := e
 	err.cause = cause
 	err.Cause = cause.Error()


### PR DESCRIPTION
Fixes error:
`fmt.Errorf undefined (type string has no field or method Errorf)`

Fixes #65 