### PR TITLE
WebrpcMethods(), var methods indentation

### DIFF
--- a/_examples/golang-basics/example.gen.go
+++ b/_examples/golang-basics/example.gen.go
@@ -224,40 +224,47 @@ type GenVersions struct {
 	SchemaVersion    string `json:"SchemaVersion"`
 }
 
-var (
-	methods = map[string]method{
-		"/rpc/ExampleService/Ping": {
-			Name:        "Ping",
-			Service:     "ExampleService",
-			Annotations: map[string]string{},
-		},
-		"/rpc/ExampleService/Status": {
-			Name:        "Status",
-			Service:     "ExampleService",
-			Annotations: map[string]string{"internal": ""},
-		},
-		"/rpc/ExampleService/Version": {
-			Name:        "Version",
-			Service:     "ExampleService",
-			Annotations: map[string]string{},
-		},
-		"/rpc/ExampleService/GetUser": {
-			Name:        "GetUser",
-			Service:     "ExampleService",
-			Annotations: map[string]string{"deprecated": ""},
-		},
-		"/rpc/ExampleService/FindUser": {
-			Name:        "FindUser",
-			Service:     "ExampleService",
-			Annotations: map[string]string{},
-		},
-		"/rpc/ExampleService/LogEvent": {
-			Name:        "LogEvent",
-			Service:     "ExampleService",
-			Annotations: map[string]string{},
-		},
+var methods = map[string]method{
+	"/rpc/ExampleService/Ping": {
+		Name:        "Ping",
+		Service:     "ExampleService",
+		Annotations: map[string]string{},
+	},
+	"/rpc/ExampleService/Status": {
+		Name:        "Status",
+		Service:     "ExampleService",
+		Annotations: map[string]string{"internal": ""},
+	},
+	"/rpc/ExampleService/Version": {
+		Name:        "Version",
+		Service:     "ExampleService",
+		Annotations: map[string]string{},
+	},
+	"/rpc/ExampleService/GetUser": {
+		Name:        "GetUser",
+		Service:     "ExampleService",
+		Annotations: map[string]string{"deprecated": ""},
+	},
+	"/rpc/ExampleService/FindUser": {
+		Name:        "FindUser",
+		Service:     "ExampleService",
+		Annotations: map[string]string{},
+	},
+	"/rpc/ExampleService/LogEvent": {
+		Name:        "LogEvent",
+		Service:     "ExampleService",
+		Annotations: map[string]string{},
+	},
+}
+
+func Methods() map[string]method {
+	res := make(map[string]method, len(methods))
+	for k, v := range methods {
+		res[k] = v
 	}
-)
+
+	return res
+}
 
 var WebRPCServices = map[string][]string{
 	"ExampleService": {

--- a/_examples/golang-basics/example.gen.go
+++ b/_examples/golang-basics/example.gen.go
@@ -257,7 +257,7 @@ var methods = map[string]method{
 	},
 }
 
-func Methods() map[string]method {
+func WebrpcMethods() map[string]method {
 	res := make(map[string]method, len(methods))
 	for k, v := range methods {
 		res[k] = v

--- a/_examples/golang-imports/api.gen.go
+++ b/_examples/golang-imports/api.gen.go
@@ -157,7 +157,7 @@ var methods = map[string]method{
 	},
 }
 
-func Methods() map[string]method {
+func WebrpcMethods() map[string]method {
 	res := make(map[string]method, len(methods))
 	for k, v := range methods {
 		res[k] = v

--- a/_examples/golang-imports/api.gen.go
+++ b/_examples/golang-imports/api.gen.go
@@ -139,25 +139,32 @@ func (x *Location) Is(values ...Location) bool {
 	return false
 }
 
-var (
-	methods = map[string]method{
-			"/rpc/ExampleAPI/Ping": {
-				Name: "Ping",
-				Service: "ExampleAPI",
-				Annotations: map[string]string{},
-			},
-			"/rpc/ExampleAPI/Status": {
-				Name: "Status",
-				Service: "ExampleAPI",
-				Annotations: map[string]string{},
-			},
-			"/rpc/ExampleAPI/GetUsers": {
-				Name: "GetUsers",
-				Service: "ExampleAPI",
-				Annotations: map[string]string{},
-			},
+var methods = map[string]method{
+	"/rpc/ExampleAPI/Ping": {
+		Name: "Ping",
+		Service: "ExampleAPI",
+		Annotations: map[string]string{},
+	},
+	"/rpc/ExampleAPI/Status": {
+		Name: "Status",
+		Service: "ExampleAPI",
+		Annotations: map[string]string{},
+	},
+	"/rpc/ExampleAPI/GetUsers": {
+		Name: "GetUsers",
+		Service: "ExampleAPI",
+		Annotations: map[string]string{},
+	},
+}
+
+func Methods() map[string]method {
+	res := make(map[string]method, len(methods))
+	for k, v := range methods {
+		res[k] = v
 	}
-)
+
+	return res
+}
 
 var WebRPCServices = map[string][]string{
 	"ExampleAPI": {

--- a/types.go.tmpl
+++ b/types.go.tmpl
@@ -29,23 +29,26 @@
 
 {{- end }}
 
-var (
-	methods = map[string]method{
-		{{- range $_, $service := $services -}}
-			{{- range $_, $method := $service.Methods }}
-			"/rpc/{{$service.Name}}/{{$method.Name}}": {
-				Name: "{{$method.Name}}",
-				Service: "{{$service.Name}}",
-				Annotations: map[string]string{
-					{{- range $_, $annotation := $method.Annotations -}}
-					"{{$annotation.AnnotationType}}": "{{$annotation.Value}}",
-					{{- end -}}
-				},
-			},
-			{{- end -}}
-		{{ end }}
+var methods = map[string]method{
+	{{- range $_, $service := $services -}}
+	{{- range $_, $method := $service.Methods }}
+	"/rpc/{{$service.Name}}/{{$method.Name}}": {
+		Name: "{{$method.Name}}",
+		Service: "{{$service.Name}}",
+		Annotations: map[string]string{ {{- range $_, $annotation := $method.Annotations -}}"{{$annotation.AnnotationType}}": "{{$annotation.Value}}", {{- end -}} },
+	},
+	{{- end -}}
+    {{ end }}
+}
+
+func Methods() map[string]method {
+	res := make(map[string]method, len(methods))
+	for k, v := range methods {
+		res[k] = v
 	}
-)
+
+	return res
+}
 
 var WebRPCServices = map[string][]string{
 {{- range $_, $service := $services}}

--- a/types.go.tmpl
+++ b/types.go.tmpl
@@ -41,7 +41,7 @@ var methods = map[string]method{
     {{ end }}
 }
 
-func Methods() map[string]method {
+func WebrpcMethods() map[string]method {
 	res := make(map[string]method, len(methods))
 	for k, v := range methods {
 		res[k] = v


### PR DESCRIPTION
Methods function:
```go
func WebrpcMethods() map[string]method {
	res := make(map[string]method, len(methods))
	for k, v := range methods {
		res[k] = v
	}

	return res
}
```

Example of var methods fixed indentation
Before:
```go
var (
	methods = map[string]method{
		"/rpc/ExampleService/Ping": {
			Name:        "Ping",
			Service:     "ExampleService",
			Annotations: map[string]string{"internal": ""},
		},
		"/rpc/ExampleService/Status": {
			Name:        "Status",
			Service:     "ExampleService",
			Annotations: map[string]string{"internal": ""},
		},
	}
)
```
After:
```go
var methods = map[string]method{
	"/rpc/ExampleService/Ping": {
		Name:        "Ping",
		Service:     "ExampleService",
		Annotations: map[string]string{},
	},
	"/rpc/ExampleService/Status": {
		Name:        "Status",
		Service:     "ExampleService",
		Annotations: map[string]string{"internal": ""},
	},
}
```