### PR TITLE
method getter functions

### DIFF
--- a/_examples/golang-basics/example.gen.go
+++ b/_examples/golang-basics/example.gen.go
@@ -234,34 +234,34 @@ type GenVersions struct {
 
 var methods = map[string]method{
 	"/rpc/ExampleService/Ping": {
-		Name:        "Ping",
-		Service:     "ExampleService",
-		Annotations: map[string]string{},
+		name:        "Ping",
+		service:     "ExampleService",
+		annotations: map[string]string{},
 	},
 	"/rpc/ExampleService/Status": {
-		Name:        "Status",
-		Service:     "ExampleService",
-		Annotations: map[string]string{"internal": ""},
+		name:        "Status",
+		service:     "ExampleService",
+		annotations: map[string]string{"internal": ""},
 	},
 	"/rpc/ExampleService/Version": {
-		Name:        "Version",
-		Service:     "ExampleService",
-		Annotations: map[string]string{},
+		name:        "Version",
+		service:     "ExampleService",
+		annotations: map[string]string{},
 	},
 	"/rpc/ExampleService/GetUser": {
-		Name:        "GetUser",
-		Service:     "ExampleService",
-		Annotations: map[string]string{"deprecated": ""},
+		name:        "GetUser",
+		service:     "ExampleService",
+		annotations: map[string]string{"deprecated": ""},
 	},
 	"/rpc/ExampleService/FindUser": {
-		Name:        "FindUser",
-		Service:     "ExampleService",
-		Annotations: map[string]string{},
+		name:        "FindUser",
+		service:     "ExampleService",
+		annotations: map[string]string{},
 	},
 	"/rpc/ExampleService/LogEvent": {
-		Name:        "LogEvent",
-		Service:     "ExampleService",
-		Annotations: map[string]string{},
+		name:        "LogEvent",
+		service:     "ExampleService",
+		annotations: map[string]string{},
 	},
 }
 
@@ -891,9 +891,26 @@ func HTTPRequestHeaders(ctx context.Context) (http.Header, bool) {
 //
 
 type method struct {
-	Name        string
-	Service     string
-	Annotations map[string]string
+	name        string
+	service     string
+	annotations map[string]string
+}
+
+func (m method) Name() string {
+	return m.name
+}
+
+func (m method) Service() string {
+	return m.service
+}
+
+func (m method) Annotations() map[string]string {
+	res := make(map[string]string, len(m.annotations))
+	for k, v := range m.annotations {
+		res[k] = v
+	}
+
+	return res
 }
 
 type contextKey struct {

--- a/_examples/golang-basics/example.gen.go
+++ b/_examples/golang-basics/example.gen.go
@@ -668,7 +668,6 @@ func NewExampleServiceClient(addr string, client HTTPClient) ExampleServiceClien
 }
 
 func (c *exampleServiceClient) Ping(ctx context.Context) error {
-
 	resp, err := doHTTPRequest(ctx, c.client, c.urls[0], nil, nil)
 	if resp != nil {
 		cerr := resp.Body.Close()
@@ -717,6 +716,7 @@ func (c *exampleServiceClient) GetUser(ctx context.Context, header map[string]st
 		Arg0 map[string]string `json:"header"`
 		Arg1 uint64            `json:"userID"`
 	}{header, userID}
+
 	out := struct {
 		Ret0 *User `json:"user"`
 	}{}
@@ -736,6 +736,7 @@ func (c *exampleServiceClient) FindUser(ctx context.Context, s *SearchFilter) (s
 	in := struct {
 		Arg0 *SearchFilter `json:"s"`
 	}{s}
+
 	out := struct {
 		Ret0 string `json:"name"`
 		Ret1 *User  `json:"user"`

--- a/_examples/golang-imports/api.gen.go
+++ b/_examples/golang-imports/api.gen.go
@@ -422,7 +422,6 @@ func NewExampleAPIClient(addr string, client HTTPClient) ExampleAPIClient {
 }
 
 func (c *exampleAPIClient) Ping(ctx context.Context) error {
-
 	resp, err := doHTTPRequest(ctx, c.client, c.urls[0], nil, nil)
 	if resp != nil {
 		cerr := resp.Body.Close()

--- a/_examples/golang-imports/api.gen.go
+++ b/_examples/golang-imports/api.gen.go
@@ -141,19 +141,19 @@ func (x *Location) Is(values ...Location) bool {
 
 var methods = map[string]method{
 	"/rpc/ExampleAPI/Ping": {
-		Name: "Ping",
-		Service: "ExampleAPI",
-		Annotations: map[string]string{},
+		name: "Ping",
+		service: "ExampleAPI",
+		annotations: map[string]string{},
 	},
 	"/rpc/ExampleAPI/Status": {
-		Name: "Status",
-		Service: "ExampleAPI",
-		Annotations: map[string]string{},
+		name: "Status",
+		service: "ExampleAPI",
+		annotations: map[string]string{},
 	},
 	"/rpc/ExampleAPI/GetUsers": {
-		Name: "GetUsers",
-		Service: "ExampleAPI",
-		Annotations: map[string]string{},
+		name: "GetUsers",
+		service: "ExampleAPI",
+		annotations: map[string]string{},
 	},
 }
 
@@ -590,9 +590,26 @@ func HTTPRequestHeaders(ctx context.Context) (http.Header, bool) {
 //
 
 type method struct  {
-	Name string
-	Service string
-	Annotations map[string]string
+	name string
+	service string
+	annotations map[string]string
+}
+
+func (m method)Name() string {
+    return m.name
+}
+
+func (m method)Service() string {
+    return m.service
+}
+
+func (m method)Annotations() map[string]string {
+    res := make(map[string]string, len(m.annotations))
+	for k, v := range m.annotations {
+		res[k] = v
+	}
+
+	return res
 }
 
 type contextKey struct {

--- a/client.go.tmpl
+++ b/client.go.tmpl
@@ -49,7 +49,7 @@ func (c *{{$serviceNameClient}}) {{$method.Name}}(ctx context.Context{{range $_,
 	{{- range $i, $input := $method.Inputs}}
 		Arg{{$i}} {{template "field" dict "Name" $input.Name "Type" $input.Type "Optional" $input.Optional "TypeMap" $typeMap "TypePrefix" $typePrefix "TypeMeta" $input.Meta "JsonTags" true}}
 	{{- end}}
-	}{ {{- range $i, $input := $method.Inputs}}{{if gt $i 0}}, {{end}}{{$input.Name}}{{end}}}
+	}{ {{- range $i, $input := $method.Inputs}}{{if gt $i 0}}, {{end}}{{$input.Name}}{{end}}}{{ "\n" }}
 	{{- end}}
 	{{- if $method.Outputs | len}}
 	{{- $outputVar = "&out"}}
@@ -57,9 +57,8 @@ func (c *{{$serviceNameClient}}) {{$method.Name}}(ctx context.Context{{range $_,
 	{{- range $i, $output := $method.Outputs}}
 		Ret{{$i}} {{template "field" dict "Name" $output.Name "Type" $output.Type "Optional" $output.Optional "TypeMap" $typeMap "TypePrefix" $typePrefix "TypeMeta" $output.Meta "JsonTags" true}}
 	{{- end}}
-	}{}
+	}{}{{ "\n" }}
 	{{- end }}
-
 	resp, err := doHTTPRequest(ctx, c.client, c.urls[{{$i}}], {{$inputVar}}, {{$outputVar}})
 	if resp != nil {
 		cerr := resp.Body.Close()
@@ -81,9 +80,8 @@ func (c *{{$serviceNameClient}}) {{$method.Name}}(ctx context.Context{{range $_,
 	{{- range $i, $input := $method.Inputs}}
 		Arg{{$i}} {{template "field" dict "Name" $input.Name "Type" $input.Type "Optional" $input.Optional "TypeMap" $typeMap "TypePrefix" $typePrefix "TypeMeta" $input.Meta "JsonTags" true}}
 	{{- end}}
-	}{ {{- range $i, $input := $method.Inputs}}{{if gt $i 0}}, {{end}}{{$input.Name}}{{end}}}
+	}{ {{- range $i, $input := $method.Inputs}}{{if gt $i 0}}, {{end}}{{$input.Name}}{{end}}}{{ "\n" }}
 	{{- end}}
-
 	resp, err := doHTTPRequest(ctx, c.client, c.urls[{{$i}}], {{$inputVar}}, nil)
 	if err != nil {
 		if resp != nil {

--- a/helpers.go.tmpl
+++ b/helpers.go.tmpl
@@ -6,9 +6,26 @@
 //
 
 type method struct  {
-	Name string
-	Service string
-	Annotations map[string]string
+	name string
+	service string
+	annotations map[string]string
+}
+
+func (m method)Name() string {
+    return m.name
+}
+
+func (m method)Service() string {
+    return m.service
+}
+
+func (m method)Annotations() map[string]string {
+    res := make(map[string]string, len(m.annotations))
+	for k, v := range m.annotations {
+		res[k] = v
+	}
+
+	return res
 }
 
 type contextKey struct {

--- a/types.go.tmpl
+++ b/types.go.tmpl
@@ -33,9 +33,9 @@ var methods = map[string]method{
 	{{- range $_, $service := $services -}}
 	{{- range $_, $method := $service.Methods }}
 	"/rpc/{{$service.Name}}/{{$method.Name}}": {
-		Name: "{{$method.Name}}",
-		Service: "{{$service.Name}}",
-		Annotations: map[string]string{ {{- range $_, $annotation := $method.Annotations -}}"{{$annotation.AnnotationType}}": "{{$annotation.Value}}", {{- end -}} },
+		name: "{{$method.Name}}",
+		service: "{{$service.Name}}",
+		annotations: map[string]string{ {{- range $_, $annotation := $method.Annotations -}}"{{$annotation.AnnotationType}}": "{{$annotation.Value}}", {{- end -}} },
 	},
 	{{- end -}}
     {{ end }}


### PR DESCRIPTION
Breaking change: Added getters for `method` so it can be used with interfaces to fetch values with helper functions, without need to use reflect.

```go
type method struct {
	name        string
	service     string
	annotations map[string]string
}

func (m method) Name() string {
	return m.name
}

func (m method) Service() string {
	return m.service
}

func (m method) Annotations() map[string]string {
	res := make(map[string]string, len(m.annotations))
	for k, v := range m.annotations {
		res[k] = v
	}

	return res
}
```

---
Added new line after `in` and `out` parameters, instead of one hardcoded new line, for better readability.

Before:
```go
func (c *exampleServiceClient) Ping(ctx context.Context) error {

	resp, err := doHTTPRequest(ctx, c.client, c.urls[0], nil, nil)
```

After:
```go
func (c *exampleServiceClient) Ping(ctx context.Context) error {
	resp, err := doHTTPRequest(ctx, c.client, c.urls[0], nil, nil)
```