### PR TITLE
fix: chunk encoding issue

### DIFF
--- a/server.go.tmpl
+++ b/server.go.tmpl
@@ -206,11 +206,15 @@ func (s *{{$serviceName}}) serve{{firstLetterToUpper $method.Name}}JSONStream(ct
 
 	// Call service method implementation.
 	if err {{if or (eq (len $method.Inputs) 0) (gt (len $method.Outputs) 0)}}:{{end}}= s.{{$name}}.{{$method.Name}}(ctx{{range $i, $_ := $method.Inputs}}, reqPayload.Arg{{$i}}{{end}}, streamWriter); err != nil {
+		cancel()
 		rpcErr, ok := err.(WebRPCError)
 		if !ok {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
+		streamWriter.mu.Lock()
 		streamWriter.sendError(w, r, rpcErr)
+		streamWriter.f.Flush()
+		streamWriter.mu.Unlock()
 		return
 	}
 }

--- a/types.go.tmpl
+++ b/types.go.tmpl
@@ -150,22 +150,21 @@ func (w *streamWriter) keepAlive(ctx context.Context) {
 }
 
 func (w *streamWriter) ping() error {
-	defer w.f.Flush()
-
 	w.mu.Lock()
-	defer w.mu.Unlock()
-
 	_, err := w.w.Write([]byte("\n"))
+	w.f.Flush()
+	w.mu.Unlock()
+
 	return err
 }
 
 func (w *streamWriter) write(respPayload interface{}) error {
-	defer w.f.Flush()
-
 	w.mu.Lock()
-	defer w.mu.Unlock()
+	err := w.e.Encode(respPayload)
+	w.f.Flush()
+	w.mu.Unlock()
 
-	return w.e.Encode(respPayload)
+	return err
 }
 {{- end }}
 


### PR DESCRIPTION
We had bugs in `streamWriter` (`ping`, `write`), because `Flush` was called after releasing the mutex; `sendError` without mutex. That caused `ERR_INVALID_CHUNKED_ENCODING` error (stream lost).
