### PR TITLE
feat: emit values slice for string enums

### DIFF
--- a/_examples/golang-basics/example.gen.go
+++ b/_examples/golang-basics/example.gen.go
@@ -232,6 +232,12 @@ const (
 	Intent_validateSession Intent = "validateSession"
 )
 
+var Intent_values = []Intent{
+	Intent_openSession,
+	Intent_closeSession,
+	Intent_validateSession,
+}
+
 func (x Intent) MarshalText() ([]byte, error) {
 	return []byte(x), nil
 }

--- a/enumString.go.tmpl
+++ b/enumString.go.tmpl
@@ -14,6 +14,12 @@
     {{- end}}
     )
 
+    var {{$name}}_values = []{{$name}}{
+    {{- range $fields}}
+        {{$name}}_{{.Name}},
+    {{- end}}
+    }
+
     func (x {{$name}}) MarshalText() ([]byte, error) {
     return []byte(x), nil
     }


### PR DESCRIPTION
## Summary

Numeric enums already emit `<Name>_name` (value→string) and `<Name>_value` (string→value) maps, but string enums had no equivalent — callers had to hand-maintain a list of known values whenever they wanted to iterate, validate, or render the set.

This adds a `<Name>_values []<Name>` slice for string enums.

### Generated output

For:
```ridl
enum Intent: string
  - openSession
  - closeSession
  - validateSession
```

…the generator now emits:

```go
var Intent_values = []Intent{
    Intent_openSession,
    Intent_closeSession,
    Intent_validateSession,
}
```

Naming uses `_values` (plural) to differentiate from the numeric-enum `_value` map.

## Test plan

- [x] `make generate` in `_examples/` regenerates cleanly
- [x] `_examples/golang-basics/example.gen.go` now contains `Intent_values` and `gofmt` is clean
- [x] Numeric enum (`Kind`) output is unchanged