### PR TITLE
docs(readme): document -schemaHash option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Change any of the following values by passing `-option="Value"` CLI flag to `web
 | `-fixEmptyArrays`     | `false`   | `encoding/json`: fix `null` arrays with reflect (see Go [#27589][go27589])  | v0.13.0  |
 | `-errorStackTrace`    | `false`   | enables error stack traces                                                  | v0.14.0  |
 | `-webrpcHeader=false` | `true`    | enable client send webrpc version in http headers                           | v0.16.0  |
+| `-schemaHash=false`   | `true`    | don't emit schema hash + version helper funcs (avoids merge conflicts)      | v0.30.0  |
 
 Example:
 ```


### PR DESCRIPTION
The `-schemaHash` opt-out shipped in v0.30.0 but never made it into the options table in the README, so it was effectively undiscoverable unless you read the template. This adds the missing row. (`-help` already lists it — that output is generated from the opts dict — so only the hand-maintained table needed updating.)

---

## Change

One row added to the options table:

| `-schemaHash=false` | `true` | don't emit schema hash + version helper funcs (avoids merge conflicts) | v0.30.0 |

`-schemaHash=false` omits the schema-hash token from the header comment and the `WebRPCVersion` / `WebRPCSchemaVersion` / `WebRPCSchemaHash` helper funcs, leaving only the Webrpc header line — which is what removes the per-edit hash churn that causes merge conflicts.

"Added in" is v0.30.0 (the release where the flag landed as opt-out, default-on). It briefly existed as opt-in in v0.29.0, but the documented default-on behavior holds from v0.30.0.

## Notes

Docs-only; no template or generated-code change. The same one-row gap exists in the other generators that shipped this flag (gen-typescript v0.28.0, gen-javascript v0.16.0, gen-openapi/kotlin/dart/swift/c) — those can be mirrored as separate follow-ups since each has its own "Added in" version and funcs-vs-consts wording.
