### PR TITLE
test(examples): wait for server readiness instead of fixed sleep

### DIFF
--- a/_examples/golang-imports/api_test.go
+++ b/_examples/golang-imports/api_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"testing"
@@ -14,18 +15,20 @@ import (
 var client ExampleAPIClient
 
 func TestMain(m *testing.M) {
-	go func() {
-		if err := startServer(); err != nil {
-			log.Fatal(err)
-		}
-	}()
-	time.Sleep(time.Millisecond * 500)
+	// Bind an ephemeral port first: the listener accepts connections before
+	// http.Serve runs, so there is no startup race and nothing to wait for.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		log.Fatal(err)
+	}
+	go http.Serve(ln, newHandler())
 
-	client = NewExampleAPIClient("http://0.0.0.0:4242", &http.Client{
+	client = NewExampleAPIClient("http://"+ln.Addr().String(), &http.Client{
 		Timeout: time.Duration(2 * time.Second),
 	})
 
 	code := m.Run()
+	ln.Close()
 	os.Exit(code)
 }
 

--- a/_examples/golang-imports/main.go
+++ b/_examples/golang-imports/main.go
@@ -19,6 +19,10 @@ func main() {
 }
 
 func startServer() error {
+	return http.ListenAndServe(":4242", newHandler())
+}
+
+func newHandler() http.Handler {
 	r := chi.NewRouter()
 	r.Use(middleware.RequestID)
 	r.Use(middleware.Logger)
@@ -31,7 +35,7 @@ func startServer() error {
 	webrpcHandler := NewExampleAPIServer(&ExampleRPC{})
 	r.Handle("/*", webrpcHandler)
 
-	return http.ListenAndServe(":4242", r)
+	return r
 }
 
 type ExampleRPC struct {


### PR DESCRIPTION
## Summary

The `golang-imports` test harness started the server on a goroutine and slept a fixed 500ms before running. On a cold runner where the server was not yet listening, the first requests timed out (this flaked while wiring up #126).

Fix it at the source instead of waiting: create the listener in the test on an ephemeral port, so it is already accepting connections before `http.Serve` runs. No sleep, no poll, no hardcoded port.

## Changes
- `_examples/golang-imports/main.go`: extract `newHandler()` so `main` and the test share the same handler.
- `_examples/golang-imports/api_test.go`: `TestMain` binds `127.0.0.1:0`, serves `newHandler()` on it, and points the client at `ln.Addr()`.

## Note on golang-basics
`golang-basics` has the same fixed-sleep pattern, but its generated code maps a type to `github.com/0xsequence/go-sequence/lib/prototyp` without the module requiring it, so the package does not build and its tests never run (it is generate+diff only in CI, see #126). Hardening its harness can't be compile-verified and would be dead code, so it's intentionally left out here; it should be hardened together with whatever fixes its build.
