### PR TITLE
fix(server): emit succinctHandler only when schema uses succinct methods

### DIFF
--- a/server.go.tmpl
+++ b/server.go.tmpl
@@ -7,6 +7,15 @@
 {{- $json := .Json -}}
 {{- $opts := .Opts -}}
 
+{{- $hasSuccinct := false -}}
+{{- range $_, $service := $services -}}
+{{- range $_, $method := $service.Methods -}}
+{{- if and $method.Succinct (not $method.StreamOutput) -}}
+{{- $hasSuccinct = true -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- if $services -}}
 //
 // Server
@@ -286,6 +295,7 @@ func RespondWithError(w http.ResponseWriter, err error) {
 	w.Write(respBody)
 }
 
+{{ if $hasSuccinct -}}
 type sendErrorFunc func(w http.ResponseWriter, r *http.Request, rpcErr WebRPCError)
 
 func succinctHandler[I any, O any](method string, fn func(context.Context, I) (O, error), sendError sendErrorFunc) func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
@@ -330,6 +340,7 @@ func succinctHandler[I any, O any](method string, fn func(context.Context, I) (O
 		w.Write(respBody)
 	}
 }
+{{ end -}}
 
 {{ end -}}
 {{ end -}}


### PR DESCRIPTION
## What

Emit the `sendErrorFunc` type and generic `succinctHandler` into server-side `.gen.go` files only when at least one non-streaming method in the schema uses the succinct RIDL syntax (`GetUser(GetUserRequest) => (GetUserResponse)`).

## Why

Since #125, the helper was emitted unconditionally into every file generated with `-server`. In schemas without succinct methods that's ~45 lines of dead code per file, which `deadcode`/`unused` linters flag in consumer repos. In the webrpc repo's own examples, 6 of 7 server files carried the unused helper after the v0.32 bump.

## Verification

- `make all` in `_examples/` — regenerated output is byte-identical for both examples (both use succinct methods), tests pass
- Generated a schema with no succinct methods against this template: `succinctHandler`/`sendErrorFunc` no longer emitted; output builds, passes `go vet`, and is gofmt-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)