### PR TITLE
feat: enable automatic migration of deprecated APIs via 'go fix'

### DIFF
--- a/_examples/golang-basics/example.gen.go
+++ b/_examples/golang-basics/example.gen.go
@@ -192,11 +192,12 @@ const (
 	KindAdmin Kind = 1
 )
 
+//go:fix inline
 const (
 	// Deprecated: Use KindUser instead.
-	Kind_USER Kind = 0
+	Kind_USER Kind = KindUser
 	// Deprecated: Use KindAdmin instead.
-	Kind_ADMIN Kind = 1
+	Kind_ADMIN Kind = KindAdmin
 )
 
 var Kind_name = map[Kind]string{
@@ -242,13 +243,14 @@ const (
 	IntentValidateSession Intent = "validateSession"
 )
 
+//go:fix inline
 const (
 	// Deprecated: Use IntentOpenSession instead.
-	Intent_openSession Intent = "openSession"
+	Intent_openSession Intent = IntentOpenSession
 	// Deprecated: Use IntentCloseSession instead.
-	Intent_closeSession Intent = "closeSession"
+	Intent_closeSession Intent = IntentCloseSession
 	// Deprecated: Use IntentValidateSession instead.
-	Intent_validateSession Intent = "validateSession"
+	Intent_validateSession Intent = IntentValidateSession
 )
 
 var Intent_values = []Intent{
@@ -288,17 +290,18 @@ const (
 	AuditActorTypeHTTPRequest AuditActorType = "httpRequest"
 )
 
+//go:fix inline
 const (
 	// Deprecated: Use AuditActorTypeService instead.
-	AuditActorType_service AuditActorType = "service"
+	AuditActorType_service AuditActorType = AuditActorTypeService
 	// Deprecated: Use AuditActorTypeAPIKey instead.
-	AuditActorType_apiKey AuditActorType = "apiKey"
+	AuditActorType_apiKey AuditActorType = AuditActorTypeAPIKey
 	// Deprecated: Use AuditActorTypeExternalURL instead.
-	AuditActorType_externalURL AuditActorType = "externalURL"
+	AuditActorType_externalURL AuditActorType = AuditActorTypeExternalURL
 	// Deprecated: Use AuditActorTypeResourceID instead.
-	AuditActorType_resourceId AuditActorType = "resourceId"
+	AuditActorType_resourceId AuditActorType = AuditActorTypeResourceID
 	// Deprecated: Use AuditActorTypeHTTPRequest instead.
-	AuditActorType_httpRequest AuditActorType = "httpRequest"
+	AuditActorType_httpRequest AuditActorType = AuditActorTypeHTTPRequest
 )
 
 var AuditActorType_values = []AuditActorType{
@@ -1258,7 +1261,7 @@ func RequestFromContext(ctx context.Context) *http.Request {
 	return r
 }
 
-// Deprecated: Use Go 1.26's new(expr).
+// Deprecated: Use Go 1.26's new(expr). Migrate automatically with: go fix ./...
 func PtrTo[T any](v T) *T { return &v }
 
 func ResponseWriterFromContext(ctx context.Context) http.ResponseWriter {

--- a/_examples/golang-imports/api.gen.go
+++ b/_examples/golang-imports/api.gen.go
@@ -88,11 +88,12 @@ const (
 	LocationNewYork Location = 1
 )
 
+//go:fix inline
 const (
 	// Deprecated: Use LocationToronto instead.
-	Location_TORONTO Location = 0
+	Location_TORONTO Location = LocationToronto
 	// Deprecated: Use LocationNewYork instead.
-	Location_NEW_YORK Location = 1
+	Location_NEW_YORK Location = LocationNewYork
 )
 
 var Location_name = map[Location]string{
@@ -664,7 +665,7 @@ func RequestFromContext(ctx context.Context) *http.Request {
 	return r
 }
 
-// Deprecated: Use Go 1.26's new(expr).
+// Deprecated: Use Go 1.26's new(expr). Migrate automatically with: go fix ./...
 func PtrTo[T any](v T) *T { return &v }
 
 func ResponseWriterFromContext(ctx context.Context) http.ResponseWriter {

--- a/enum.go.tmpl
+++ b/enum.go.tmpl
@@ -20,10 +20,11 @@ const (
 {{- end}}
 )
 
+//go:fix inline
 const (
 {{- range $_, $field := $fields }}
 	// Deprecated: Use {{template "enumConstName" dict "EnumName" $name "FieldName" .Name}} instead.
-	{{template "enumLegacyConstName" dict "EnumName" $name "FieldName" .Name}} {{$name}} = {{$field.Value}}
+	{{template "enumLegacyConstName" dict "EnumName" $name "FieldName" .Name}} {{$name}} = {{template "enumConstName" dict "EnumName" $name "FieldName" .Name}}
 {{- end}}
 )
 

--- a/enumString.go.tmpl
+++ b/enumString.go.tmpl
@@ -14,10 +14,11 @@
     {{- end}}
     )
 
+    //go:fix inline
     const (
     {{- range $fields}}
         // Deprecated: Use {{template "enumConstName" dict "EnumName" $name "FieldName" .Name}} instead.
-        {{template "enumLegacyConstName" dict "EnumName" $name "FieldName" .Name}} {{$name}} = "{{.Value}}"
+        {{template "enumLegacyConstName" dict "EnumName" $name "FieldName" .Name}} {{$name}} = {{template "enumConstName" dict "EnumName" $name "FieldName" .Name}}
     {{- end}}
     )
 

--- a/helpers.go.tmpl
+++ b/helpers.go.tmpl
@@ -43,7 +43,7 @@ func RequestFromContext(ctx context.Context) *http.Request {
 }
 {{- end}}
 
-// Deprecated: Use Go 1.26's new(expr).
+// Deprecated: Use Go 1.26's new(expr). Migrate automatically with: go fix ./...
 func PtrTo[T any](v T) *T { return &v }
 
 {{ if $opts.server}}


### PR DESCRIPTION
Let users of the generated code migrate off deprecated APIs by
running 'go fix ./...' with a Go 1.26+ toolchain:

- Legacy enum constants (e.g. Kind_USER) now forward to their new
  names (KindUser) and are marked with the //go:fix inline
  directive, so 'go fix' rewrites call sites in user code. One
  directive per const group covers all constants in the group.

- PtrTo() calls are rewritten to Go 1.26's new(expr) builtin by
  the 'newexpr' modernizer bundled in 'go fix'. This requires no
  directive: the modernizer pattern-matches the 'return &v' body,
  so PtrTo must keep that exact shape. The rewrite only applies in
  modules declaring go >= 1.26.

Older toolchains ignore the directive, so generated code remains
fully backward compatible.
